### PR TITLE
Reduce memory leak of Tokens

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -87,6 +87,7 @@ int main(int argc, char * const *argv)
         if (topToken->next == NULL) {
           break;
         } else {
+          topToken->refCount--;
           topToken = topToken->next;
         }
       }

--- a/src/token.c
+++ b/src/token.c
@@ -12,6 +12,7 @@ Token *Token_new(void)
   self->type = ON_NONE;
   self->prev = NULL;
   self->next = NULL;
+  self->done = false;
   return self;
 }
 

--- a/src/token.c
+++ b/src/token.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "debug.h"
 #include "common.h"
 #include "token.h"
 
@@ -12,12 +13,13 @@ Token *Token_new(void)
   self->type = ON_NONE;
   self->prev = NULL;
   self->next = NULL;
-  self->done = false;
+  self->refCount = 1;
   return self;
 }
 
 void Token_free(Token* self)
 {
+  DEBUG("free `%s`", self->value);
   free(self->value);
   free(self);
 }
@@ -27,4 +29,19 @@ bool Token_exists(Token* const self)
   if (strlen(self->value) > 0)
     return true;
   return false;
+}
+
+void Token_GC(Token* currentToken)
+{
+  DEBUG("GC start");
+  Token *prev;
+  while (currentToken->prev) {
+    prev = currentToken->prev;
+    if (currentToken->prev->refCount == 0) {
+      Token_free(currentToken->prev);
+      currentToken->prev = NULL;
+    }
+    currentToken = prev;
+  }
+  DEBUG("GC end");
 }

--- a/src/token.h
+++ b/src/token.h
@@ -78,6 +78,7 @@ typedef struct token
   struct token *prev;
   struct token *next;
   char *value;
+  bool done;
 } Token;
 
 Token *Token_new(void);

--- a/src/token.h
+++ b/src/token.h
@@ -78,12 +78,14 @@ typedef struct token
   struct token *prev;
   struct token *next;
   char *value;
-  bool done;
+  int refCount;
 } Token;
 
 Token *Token_new(void);
 
 void Token_free(Token* self);
+
+void Token_GC(Token* token);
 
 bool Token_exists(Token* const self);
 


### PR DESCRIPTION
## before

```
$ valgrind ./cli/mmrbc test/fixtures/wifi.rb 1> /dev/null
==2928== Memcheck, a memory error detector
==2928== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2928== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==2928== Command: ./cli/mmrbc test/fixtures/wifi.rb
==2928== 
==2928== 
==2928== HEAP SUMMARY:
==2928==     in use at exit: 14,492 bytes in 548 blocks
==2928==   total heap usage: 90,858 allocs, 90,310 frees, 7,107,900 bytes allocated
==2928== 
==2928== LEAK SUMMARY:
==2928==    definitely lost: 80 bytes in 17 blocks
==2928==    indirectly lost: 14,412 bytes in 531 blocks
==2928==      possibly lost: 0 bytes in 0 blocks
==2928==    still reachable: 0 bytes in 0 blocks
==2928==         suppressed: 0 bytes in 0 blocks
==2928== Rerun with --leak-check=full to see details of leaked memory
==2928== 
==2928== For counts of detected and suppressed errors, rerun with: -v
==2928== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

```
$ valgrind --tool=massif ./cli/mmrbc test/fixtures/wifi.rb
$ ms_print massif.out.* | less
--------------------------------------------------------------------------------
Command:            ./cli/mmrbc test/fixtures/wifi.rb
Massif arguments:   (none)
ms_print arguments: massif.out.2790
--------------------------------------------------------------------------------


    KB
37.68^                                                                       #
     |                                                                 @ @ @ #
     |                                                           @ @ @ @ @ @ #
     |                                                    @ @  @ @ @ @ @ @ @ #
     |                                                 @  @ @  @ @ @ @ @:@ @:#
     |                                                 @  @ @  @:@ @ @:@:@:@:#
     |                                                 @  @ @  @:@:@:@:@:@:@:#
     |                   @@          @ @               @  @:@::@:@:@:@:@:@:@:#
     |                   @           @ @            :::@::@:@::@:@:@:@:@:@:@:#
     |                   @           @ @   :  ::    : :@::@:@::@:@:@:@:@:@:@:#
     |                   @           @ @  ::  ::::::: :@::@:@::@:@:@:@:@:@:@:#
     |                   @   ::   : :@:@: ::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
     |            :: ::  @   :  :::::@:@::::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
     |        :   :  :  :@ ::: :: :::@:@::::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
     |    :   : : : :: ::@ ::: :: :::@:@::::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
     | :  : ::: ::: :: ::@ ::: :: :::@:@::::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
     | :@ ::::::::: :: ::@ ::: :: :::@:@::::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
     | :@:::::::::: :: ::@ ::: :: :::@:@::::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
     | :@:::::::::: :: ::@ ::: :: :::@:@::::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
     | :@:::::::::: :: ::@ ::: :: :::@:@::::::::: ::: :@::@:@::@:@:@:@:@:@:@:#
   0 +----------------------------------------------------------------------->Mi
     0                                                                   25.63

Number of snapshots: 84
 Detailed snapshots: [2, 18, 28, 30, 46, 51, 54, 58, 62, 66, 69, 72, 76, 79, 82 (peak)]

```

## after

```
$ valgrind ./cli/mmrbc test/fixtures/wifi.rb 1> /dev/null
==9101== Memcheck, a memory error detector
==9101== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==9101== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==9101== Command: ./cli/mmrbc test/fixtures/wifi.rb
==9101== 
==9101== Invalid read of size 8
...
# I ignore some `Invalid read of size 8`
# see https://www.gcd.org/blog/2007/11/138/
...
==9101== 
==9101== HEAP SUMMARY:
==9101==     in use at exit: 0 bytes in 0 blocks
==9101==   total heap usage: 90,890 allocs, 90,890 frees, 7,111,772 bytes allocated
==9101== 
==9101== All heap blocks were freed -- no leaks are possible
==9101== 
==9101== For counts of detected and suppressed errors, rerun with: -v
==9101== ERROR SUMMARY: 338 errors from 5 contexts (suppressed: 0 from 0)
```

```
$ valgrind --tool=massif ./cli/mmrbc test/fixtures/wifi.rb
$ ms_print massif.out.* | less
--------------------------------------------------------------------------------
Command:            ./cli/mmrbc test/fixtures/wifi.rb
Massif arguments:   (none)
ms_print arguments: massif.out.9135
--------------------------------------------------------------------------------


    KB
19.03^                   ##                                                   
     |                   #                                                    
     |                   #                                                    
     |                   #                                                    
     |                   #                                                    
     |                   #                                                    
     |                   #                                                    
     |     :             #                   :                   :            
     |     :             #                   :     ::            :   :  :     
     |   :::             #               :   :     :     :::     :   :  :   @ 
     |   : :  :: ::     :# ::    :     : : ::::    :  :: : :     :   :  : : @ 
     |@@:: :  ::::::::@ :# :::   :     : ::::::@   :  : :: :    :::  :  ::: @:
     |@ :: : :::::::: @ :# :::::::: :::: ::::::@   : :: :: : : ::@::::: ::::@:
     |@ :: : :::::::: @ :# ::::: : :: :: ::::::@:: : :: :: : : ::@::::@:::::@:
     |@ :: :::::::::: @::# ::::: : :: ::@::::::@: :: :: :: ::::::@::::@:::::@:
     |@ :: :::::::::: @::# ::::: : :: ::@::::::@: :: :: :: : ::::@::::@:::::@:
     |@ :: :::::::::: @::# ::::: : :: ::@::::::@: :: :: :: : ::::@::::@:::::@:
     |@ :: :::::::::: @::# ::::: : :: ::@::::::@: :: :: :: : ::::@::::@:::::@:
     |@ :: :::::::::: @::# ::::: : :: ::@::::::@: :: :: :: : ::::@::::@:::::@:
     |@ :: :::::::::: @::# ::::: : :: ::@::::::@: :: :: :: : ::::@::::@:::::@:
   0 +----------------------------------------------------------------------->Mi
     0                                                                   25.00

Number of snapshots: 73
 Detailed snapshots: [1, 14, 17 (peak), 29, 36, 50, 60, 70]
```