### PR TITLE
Mrubyc integrate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/ruby-lemon-parse"]
 	path = src/ruby-lemon-parse
 	url = https://github.com/hasumikin/ruby-lemon-parse.git
+[submodule "src/mrubyc"]
+	path = src/mrubyc
+	url = https://github.com/hasumikin/mrubyc.git

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	cd src ; $(MAKE) all
+#	cd src ; $(MAKE) all
 	cd cli ; $(MAKE) all
 
 debug: all

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,17 +1,18 @@
 #CFLAGS += -Wall -Wpointer-arith -std=c99 -Os
-CFLAGS += -Wall -Wpointer-arith -std=c99 -g -O0 -DDEBUG_BUILD
+CFLAGS += -Wall -Wpointer-arith -std=gnu99 -g -O0 -DDEBUG_BUILD
 CC = gcc
 LDFLAGS +=
 TARGET = mmrbc
-LIBMMRBC = ../src/libmmrbc.a
+MRUBYCSRCDIR = ../src/mrubyc/src
+PARSE = ../src/ruby-lemon-parse/parse
 
-all: $(TARGET)
+all: $(TARGET) $(PARSE).c
 
-$(TARGET): main.c $(LIBMMRBC)
+$(TARGET): main.c ../src/*.c $(PARSE).c $(MRUBYCSRCDIR)/*.c $(MRUBYCSRCDIR)/hal/*.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
-$(LIBMMRBC):
-	cd ../src ; $(MAKE) all
+$(PARSE).c: $(PARSE).y
+	cd ../src/ruby-lemon-parse/ ; $(MAKE) all
 
 clean:
 	rm -f $(TARGET)

--- a/cli/main.c
+++ b/cli/main.c
@@ -9,6 +9,9 @@
 #include "../src/mmrbc.h"
 #include "../src/tokenizer.h"
 
+int alloc_count;
+int free_count;
+
 int handle_opt(int argc, char * const *argv)
 {
   struct option longopts[] = {
@@ -80,6 +83,9 @@ int main(int argc, char * const *argv)
   mrbc_init(memory_pool, MEMORY_SIZE);
   print_memory();
 
+  alloc_count = 0;
+  free_count = 0;
+
   FILE *fp;
   if( (fp = fopen( argv[optind], "r" ) ) == NULL ) {
     FATAL("mmrbc: cannot open program file. (%s)", *argv);
@@ -113,5 +119,8 @@ int main(int argc, char * const *argv)
     Tokenizer_free(tokenizer);
   }
   print_memory();
+
+  printf("alloc_count: %d\n", alloc_count);
+  printf("free_count: %d\n", free_count);
   return 0;
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,11 +9,14 @@ OBJS = $(SRCS:.c=.o)
 all:
 	$(MAKE) $(TARGET)
 
-$(TARGET): ruby-lemon-parse/parse.o $(OBJS)
+$(TARGET): mrubyc/src/alloc.o ruby-lemon-parse/parse.o $(OBJS)
 	$(AR) $(ARFLAGS) $@ $^
 
 ruby-lemon-parse/parse.c:
 	cd ruby-lemon-parse ; $(MAKE) all
+
+mrubyc/src/alloc.o:
+	cd mrubyc/src ; $(MAKE) all
 
 token.o: common.h debug.h mmrbc.h token.h token.c
 
@@ -27,4 +30,5 @@ common.o: common.h debug.h common.c
 
 clean:
 	cd ruby-lemon-parse ; $(MAKE) clean
+	cd mrubyc/src ; $(MAKE) clean
 	rm -f $(TARGET) $(OBJS)

--- a/src/common.c
+++ b/src/common.c
@@ -1,26 +1,43 @@
 #include <string.h>
+#include <stdlib.h>
 #include "common.h"
 #include "debug.h"
 
+#include "mrubyc/src/mrubyc.h"
 #include "mrubyc/src/alloc.h"
 
 int alloc_count = 0;
 int free_count = 0;
 
+void print_memory(void)
+{
+#ifndef MRBC_ALLOC_LIBC
+  int total, used, free, fragment;
+  mrbc_alloc_statistics( &total, &used, &free, &fragment );
+  DEBUG("Memory total:%d, used:%d, free:%d, fragment:%d", total, used, free, fragment );
+#endif
+}
+
+void print_allocs(void)
+{
+  INFO("alloc_count: %d\n", alloc_count);
+  INFO("free_count: %d\n", free_count);
+}
+
 void *mmrbc_alloc(size_t size)
 {
+  void *ptr;
   alloc_count++;
-  return malloc(size);
-  //return mrbc_raw_alloc(size);
+  ptr = ALLOC(size);
+  DEBUG("alloc: %p, size: %d", ptr, (int)size);
+  return ptr;
 }
 
 void mmrbc_free(void *ptr)
 {
-  //if (ptr == NULL) return;
+  DEBUG("free: %p", ptr);
   free_count++;
-  free(ptr);
-  //mrbc_raw_free(ptr);
-  ptr = NULL;
+  FREE(ptr);
 }
 
 char *strsafencpy(char *s1, const char *s2, size_t n, size_t max)

--- a/src/common.c
+++ b/src/common.c
@@ -2,6 +2,27 @@
 #include "common.h"
 #include "debug.h"
 
+#include "mrubyc/src/alloc.h"
+
+int alloc_count = 0;
+int free_count = 0;
+
+void *mmrbc_alloc(size_t size)
+{
+  alloc_count++;
+  return malloc(size);
+  //return mrbc_raw_alloc(size);
+}
+
+void mmrbc_free(void *ptr)
+{
+  //if (ptr == NULL) return;
+  free_count++;
+  free(ptr);
+  //mrbc_raw_free(ptr);
+  ptr = NULL;
+}
+
 char *strsafencpy(char *s1, const char *s2, size_t n, size_t max)
 {
   DEBUG("s1: `%s`, s2: `%s`, n: %d, max: %d", s1, s2, (int)n, (int)max);

--- a/src/common.h
+++ b/src/common.h
@@ -1,9 +1,22 @@
 #ifndef MMRBC_COMMON_H_
 #define MMRBC_COMMON_H_
 
+#ifdef MRBC_ALLOC_LIBC
+  #include <stdlib.h>
+  #define ALLOC(size) malloc(size)
+  #define FREE(ptr)   free(ptr)
+#else
+  #define ALLOC(size) mrbc_raw_alloc(size)
+  #define FREE(ptr)   mrbc_raw_free(ptr)
+#endif /* MMRBC_ALLOC_LIBC */
+
 #define MAX_LINE_LENGTH 256
 
 #define MAX_TOKEN_LENGTH 256
+
+void print_memory(void);
+
+void print_allocs(void);
 
 void *mmrbc_alloc(size_t size);
 
@@ -15,4 +28,4 @@ char *strsafencpy(char *s1, const char *s2, size_t n, size_t max);
 
 char *strsafecat(char *dst, const char *src, size_t max);
 
-#endif
+#endif /* MMRBC_COMMON_H_ */

--- a/src/common.h
+++ b/src/common.h
@@ -5,6 +5,10 @@
 
 #define MAX_TOKEN_LENGTH 256
 
+void *mmrbc_alloc(size_t size);
+
+void mmrbc_free(void *ptr);
+
 char *strsafecpy(char *str1, const char *str2, size_t max);
 
 char *strsafencpy(char *s1, const char *s2, size_t n, size_t max);

--- a/src/debug.h
+++ b/src/debug.h
@@ -70,4 +70,3 @@ int loglevel;
                            fprintf(stderr, fmt, ##__VA_ARGS__),\
                            fprintf(stderr, "\n"))
 #endif /* DEBUG_BUILD */
-

--- a/src/mmrbc.h
+++ b/src/mmrbc.h
@@ -1,6 +1,7 @@
 #ifndef MMRBC_MMRBC_H_
 #define MMRBC_MMRBC_H_
 
+#include "mrubyc/src/mrubyc.h"
 #include "banned.h"
 #include "debug.h"
 #include "version.h"

--- a/src/token.c
+++ b/src/token.c
@@ -2,13 +2,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mrubyc/src/alloc.h"
+
 #include "debug.h"
 #include "common.h"
 #include "token.h"
 
 Token *Token_new(void)
 {
-  Token *self = malloc(sizeof(Token));
+  Token *self = mrbc_raw_alloc(sizeof(Token));
   self->value = NULL;
   self->type = ON_NONE;
   self->prev = NULL;
@@ -20,8 +22,8 @@ Token *Token_new(void)
 void Token_free(Token* self)
 {
   DEBUG("free `%s`", self->value);
-  free(self->value);
-  free(self);
+  //mrbc_raw_free(self->value);
+  //mrbc_raw_free(self);
 }
 
 bool Token_exists(Token* const self)

--- a/src/token.c
+++ b/src/token.c
@@ -2,15 +2,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "mrubyc/src/alloc.h"
-
 #include "debug.h"
 #include "common.h"
 #include "token.h"
 
 Token *Token_new(void)
 {
-  Token *self = mrbc_raw_alloc(sizeof(Token));
+  Token *self = mmrbc_alloc(sizeof(Token));
   self->value = NULL;
   self->type = ON_NONE;
   self->prev = NULL;
@@ -21,9 +19,10 @@ Token *Token_new(void)
 
 void Token_free(Token* self)
 {
-  DEBUG("free `%s`", self->value);
-  //mrbc_raw_free(self->value);
-  //mrbc_raw_free(self);
+  DEBUG("free Token->value: `%s`", self->value);
+  mmrbc_free(self->value);
+  DEBUG("free Token: %p", self);
+  mmrbc_free(self);
 }
 
 bool Token_exists(Token* const self)

--- a/src/token.c
+++ b/src/token.c
@@ -8,7 +8,7 @@
 
 Token *Token_new(void)
 {
-  Token *self = mmrbc_alloc(sizeof(Token));
+  Token *self = (Token *)mmrbc_alloc(sizeof(Token));
   self->value = NULL;
   self->type = ON_NONE;
   self->prev = NULL;
@@ -19,8 +19,10 @@ Token *Token_new(void)
 
 void Token_free(Token* self)
 {
-  DEBUG("free Token->value: `%s`", self->value);
-  mmrbc_free(self->value);
+  if (self->value != NULL) {
+    mmrbc_free(self->value);
+    DEBUG("free Token->value: `%s`", self->value);
+  }
   DEBUG("free Token: %p", self);
   mmrbc_free(self);
 }
@@ -34,15 +36,17 @@ bool Token_exists(Token* const self)
 
 void Token_GC(Token* currentToken)
 {
-  DEBUG("GC start");
-  Token *prev;
-  while (currentToken->prev) {
-    prev = currentToken->prev;
-    if (currentToken->prev->refCount == 0) {
-      Token_free(currentToken->prev);
-      currentToken->prev = NULL;
-    }
-    currentToken = prev;
+  DEBUG("GC start. currentToken: %p", currentToken);
+  print_memory();
+  Token *prevToken = currentToken->prev;
+  Token *temp;
+  while (prevToken) {
+    if (prevToken->refCount > 0) break;
+    prevToken->next->prev = NULL;
+    temp = prevToken->prev;
+    Token_free(prevToken);
+    prevToken = temp;
   }
+  print_memory();
   DEBUG("GC end");
 }

--- a/src/token.h
+++ b/src/token.h
@@ -83,9 +83,9 @@ typedef struct token
 
 Token *Token_new(void);
 
-void Token_free(Token* self);
+void Token_free(Token *self);
 
-void Token_GC(Token* token);
+void Token_GC(Token *currentToken);
 
 bool Token_exists(Token* const self);
 

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -90,12 +90,12 @@ static void tokenizer_paren_stack_add(Tokenizer* const self, Paren paren)
 
 Tokenizer* const Tokenizer_new(FILE *file)
 {
-  Tokenizer *self = mmrbc_alloc(sizeof(Tokenizer));
+  Tokenizer *self = (Tokenizer *)mmrbc_alloc(sizeof(Tokenizer));
   /* class vars in mmrbc.gem */
   {
     self->currentToken = Token_new();
     self->paren_stack_num = -1;
-    self->line = mmrbc_alloc(sizeof(char) * (MAX_LINE_LENGTH));
+    self->line = (char *)mmrbc_alloc(sizeof(char) * (MAX_LINE_LENGTH));
     self->line[0] = '\0';
     self->line_num = 0;
     self->pos = 0;
@@ -147,7 +147,7 @@ void tokenizer_pushToken(Tokenizer *self, int line_num, int pos, Type type, char
   self->currentToken->pos = pos;
   self->currentToken->line_num = line_num;
   self->currentToken->type = type;
-  self->currentToken->value = mmrbc_alloc(sizeof(char) * (strlen(value) + 1));
+  self->currentToken->value = (char *)mmrbc_alloc(sizeof(char) * (strlen(value) + 1));
   self->currentToken->value[0] = '\0';
   strsafecpy(self->currentToken->value, value, strlen(value) + 1);
   DEBUG("Pushed token: `%s`", self->currentToken->value);
@@ -161,6 +161,7 @@ void tokenizer_pushToken(Tokenizer *self, int line_num, int pos, Type type, char
 int Tokenizer_advance(Tokenizer* const self, bool recursive)
 {
   DEBUG("Aadvance. mode: `%d`", self->mode);
+  if (self->currentToken->prev != NULL)
   Token_GC(self->currentToken);
   Token *lazyToken = Token_new();
   char value[MAX_TOKEN_LENGTH];
@@ -192,7 +193,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = mmrbc_alloc(sizeof(char) *(2));
+        lazyToken->value = (char *)mmrbc_alloc(sizeof(char) *(2));
         *(lazyToken->value) = self->modeTerminater;
         *(lazyToken->value + 1) = '\0';
         lazyToken->state = EXPR_END;
@@ -245,7 +246,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = mmrbc_alloc(sizeof(char) *(2));
+        lazyToken->value = (char *)mmrbc_alloc(sizeof(char) *(2));
         *(lazyToken->value) = self->modeTerminater;
         *(lazyToken->value + 1) = '\0';;
         lazyToken->state = EXPR_END;
@@ -318,7 +319,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = mmrbc_alloc(sizeof(char) *(2));
+        lazyToken->value = (char *)mmrbc_alloc(sizeof(char) *(2));
         *(lazyToken->value) = '\'';
         *(lazyToken->value + 1) = '\0';
         lazyToken->state = EXPR_END;

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "mrubyc/src/alloc.h"
+
 #include "mmrbc.h"
 #include "common.h"
 #include "tokenizer.h"
@@ -90,12 +92,12 @@ static void tokenizer_paren_stack_add(Tokenizer* const self, Paren paren)
 
 Tokenizer* const Tokenizer_new(FILE *file)
 {
-  Tokenizer *self = malloc(sizeof(Tokenizer));
+  Tokenizer *self = mrbc_raw_alloc(sizeof(Tokenizer));
   /* class vars in mmrbc.gem */
   {
     self->currentToken = Token_new();
     self->paren_stack_num = -1;
-    self->line = malloc(sizeof(char) * (MAX_LINE_LENGTH));
+    self->line = mrbc_raw_alloc(sizeof(char) * (MAX_LINE_LENGTH));
     self->line[0] = '\0';
     self->line_num = 0;
     self->pos = 0;
@@ -114,8 +116,8 @@ Tokenizer* const Tokenizer_new(FILE *file)
 void Tokenizer_free(Tokenizer *self)
 {
   Token_free(self->currentToken);
-  free(self->line);
-  free(self);
+  mrbc_raw_free(self->line);
+  mrbc_raw_free(self);
 }
 
 void tokenizer_readLine(Tokenizer* const self)
@@ -147,7 +149,7 @@ void tokenizer_pushToken(Tokenizer *self, int line_num, int pos, Type type, char
   self->currentToken->pos = pos;
   self->currentToken->line_num = line_num;
   self->currentToken->type = type;
-  self->currentToken->value = malloc(sizeof(char) * (strlen(value) + 1));
+  self->currentToken->value = mrbc_raw_alloc(sizeof(char) * (strlen(value) + 1));
   self->currentToken->value[0] = '\0';
   strsafecpy(self->currentToken->value, value, strlen(value) + 1);
   DEBUG("Pushed token: `%s`", self->currentToken->value);
@@ -192,7 +194,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = malloc(sizeof(char) *(2));
+        lazyToken->value = mrbc_raw_alloc(sizeof(char) *(2));
         *(lazyToken->value) = self->modeTerminater;
         *(lazyToken->value + 1) = '\0';
         lazyToken->state = EXPR_END;
@@ -245,7 +247,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = malloc(sizeof(char) *(2));
+        lazyToken->value = mrbc_raw_alloc(sizeof(char) *(2));
         *(lazyToken->value) = self->modeTerminater;
         *(lazyToken->value + 1) = '\0';;
         lazyToken->state = EXPR_END;
@@ -318,7 +320,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = malloc(sizeof(char) *(2));
+        lazyToken->value = mrbc_raw_alloc(sizeof(char) *(2));
         *(lazyToken->value) = '\'';
         *(lazyToken->value + 1) = '\0';
         lazyToken->state = EXPR_END;

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -3,8 +3,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "mrubyc/src/alloc.h"
-
 #include "mmrbc.h"
 #include "common.h"
 #include "tokenizer.h"
@@ -92,12 +90,12 @@ static void tokenizer_paren_stack_add(Tokenizer* const self, Paren paren)
 
 Tokenizer* const Tokenizer_new(FILE *file)
 {
-  Tokenizer *self = mrbc_raw_alloc(sizeof(Tokenizer));
+  Tokenizer *self = mmrbc_alloc(sizeof(Tokenizer));
   /* class vars in mmrbc.gem */
   {
     self->currentToken = Token_new();
     self->paren_stack_num = -1;
-    self->line = mrbc_raw_alloc(sizeof(char) * (MAX_LINE_LENGTH));
+    self->line = mmrbc_alloc(sizeof(char) * (MAX_LINE_LENGTH));
     self->line[0] = '\0';
     self->line_num = 0;
     self->pos = 0;
@@ -116,8 +114,8 @@ Tokenizer* const Tokenizer_new(FILE *file)
 void Tokenizer_free(Tokenizer *self)
 {
   Token_free(self->currentToken);
-  mrbc_raw_free(self->line);
-  mrbc_raw_free(self);
+  mmrbc_free(self->line);
+  mmrbc_free(self);
 }
 
 void tokenizer_readLine(Tokenizer* const self)
@@ -149,7 +147,7 @@ void tokenizer_pushToken(Tokenizer *self, int line_num, int pos, Type type, char
   self->currentToken->pos = pos;
   self->currentToken->line_num = line_num;
   self->currentToken->type = type;
-  self->currentToken->value = mrbc_raw_alloc(sizeof(char) * (strlen(value) + 1));
+  self->currentToken->value = mmrbc_alloc(sizeof(char) * (strlen(value) + 1));
   self->currentToken->value[0] = '\0';
   strsafecpy(self->currentToken->value, value, strlen(value) + 1);
   DEBUG("Pushed token: `%s`", self->currentToken->value);
@@ -194,7 +192,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = mrbc_raw_alloc(sizeof(char) *(2));
+        lazyToken->value = mmrbc_alloc(sizeof(char) *(2));
         *(lazyToken->value) = self->modeTerminater;
         *(lazyToken->value + 1) = '\0';
         lazyToken->state = EXPR_END;
@@ -247,7 +245,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = mrbc_raw_alloc(sizeof(char) *(2));
+        lazyToken->value = mmrbc_alloc(sizeof(char) *(2));
         *(lazyToken->value) = self->modeTerminater;
         *(lazyToken->value + 1) = '\0';;
         lazyToken->state = EXPR_END;
@@ -320,7 +318,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
         lazyToken->line_num = self->line_num;
         lazyToken->pos = self->pos;
         lazyToken->type = ON_TSTRING_END;
-        lazyToken->value = mrbc_raw_alloc(sizeof(char) *(2));
+        lazyToken->value = mmrbc_alloc(sizeof(char) *(2));
         *(lazyToken->value) = '\'';
         *(lazyToken->value + 1) = '\0';
         lazyToken->state = EXPR_END;


### PR DESCRIPTION
- Submodule mrubyc
- Use `mrbc_raw_alloc` and `mrbc_raw_free`
- Able to select mrbc_raw_alloc or malloc by `CFLAGS=-DMRBC_ALLOC_LIBC`
- Fix memory leak