### PR TITLE
Fix memory leaks in Generator

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -126,7 +126,8 @@ int main(int argc, char * const *argv)
     fclose( fp );
     Parse(parser, 0, "");
     ParseShowAllNode(parser, 1);
-    scope = Generator_generate(p->root);
+    scope = Scope_new(NULL);
+    Generator_generate(scope, p->root);
     ParseFreeAllNode(parser);
     ParseFreeState(parser);
     ParseFree(parser, mmrbc_free);

--- a/cli/main.c
+++ b/cli/main.c
@@ -86,7 +86,7 @@ int main(int argc, char * const *argv)
   }
 
   mrbc_init(memory_pool, MEMORY_SIZE);
-  MrbCode *mrb;
+  Scope *scope;
 
   FILE *fp;
   if( (fp = fopen(in, "r" ) ) == NULL ) {
@@ -126,19 +126,20 @@ int main(int argc, char * const *argv)
     fclose( fp );
     Parse(parser, 0, "");
     ParseShowAllNode(parser, 1);
-    mrb = Generator_generate(p->root);
+    scope = Generator_generate(p->root);
     ParseFreeAllNode(parser);
     ParseFreeState(parser);
     ParseFree(parser, mmrbc_free);
     Tokenizer_free(tokenizer);
   }
-  print_allocs();
   if( (fp = fopen( out, "wb" ) ) == NULL ) {
     FATAL("mmrbc: cannot write a file. (%s)", out);
     return 1;
   } else {
-    fwrite(mrb->vmCode, mrb->codeSize, 1, fp);
+    fwrite(scope->vm_code, scope->vm_code_size, 1, fp);
     fclose(fp);
+    mmrbc_free(scope->vm_code);
   }
+  print_allocs();
   return 0;
 }

--- a/cli/main.c
+++ b/cli/main.c
@@ -140,6 +140,7 @@ int main(int argc, char * const *argv)
     fclose(fp);
     mmrbc_free(scope->vm_code);
   }
+  Scope_free(scope);
   print_allocs();
   return 0;
 }

--- a/src/generator.c
+++ b/src/generator.c
@@ -148,6 +148,7 @@ MrbCode *Generator_generate(Node *root)
   uint16_t crc = calc_crc_16_ccitt(&vmCode[10], codeSize - 10, 0);
   vmCode[8] = (crc >> 8) & 0xff;
   vmCode[9] = crc & 0xff;
+  Scope_freeCodeSnippets(scope);
   MrbCode *mrb = mmrbc_alloc(sizeof(MrbCode));
   mrb->codeSize = codeSize;
   mrb->vmCode = vmCode;

--- a/src/generator.c
+++ b/src/generator.c
@@ -117,14 +117,14 @@ void codegen(Scope *scope, Node *tree)
   }
 }
 
-uint8_t *flattenCode(Code *code, int codeSize)
+uint8_t *flattenCode(CodeSnippet *code_snippet, int codeSize)
 {
   uint8_t *result = mmrbc_alloc(codeSize);
   int index = 0;
-  while (code != NULL) {
-    memcpy(&result[index], code->value, code->size);
-    index += code->size;
-    code = code->next;
+  while (code_snippet != NULL) {
+    memcpy(&result[index], code_snippet->value, code_snippet->size);
+    index += code_snippet->size;
+    code_snippet = code_snippet->next;
   }
   return result;
 }
@@ -133,7 +133,7 @@ MrbCode *Generator_generate(Node *root)
 {
   Scope *scope = Scope_new(NULL);
   codegen(scope, root);
-  int irepSize = Code_size(scope->code);
+  int irepSize = Code_size(scope->code_snippet);
   int codeSize = HEADER_SIZE + irepSize + END_SECTION_SIZE;
   uint8_t *vmCode = mmrbc_alloc(codeSize);
   memcpy(&vmCode[0], "RITE0006", 8);
@@ -142,7 +142,7 @@ MrbCode *Generator_generate(Node *root)
   vmCode[12] = (codeSize >> 8) & 0xff;
   vmCode[13] = codeSize & 0xff;
   memcpy(&vmCode[14], "MATZ0000", 8);
-  memcpy(&vmCode[22], flattenCode(scope->code, irepSize), irepSize);
+  memcpy(&vmCode[22], flattenCode(scope->code_snippet, irepSize), irepSize);
   memcpy(&vmCode[22 + irepSize], "END\0\0\0\0", 7);
   vmCode[22 + irepSize + 7] = 0x08;
   uint16_t crc = calc_crc_16_ccitt(&vmCode[10], codeSize - 10, 0);

--- a/src/generator.c
+++ b/src/generator.c
@@ -127,12 +127,12 @@ void memcpyFlattenCode(uint8_t *body, CodeSnippet *code_snippet, int size)
   }
 }
 
-MrbCode *Generator_generate(Node *root)
+Scope *Generator_generate(Node *root)
 {
   Scope *scope = Scope_new(NULL);
   codegen(scope, root);
   int irepSize = Code_size(scope->code_snippet);
-  int codeSize = HEADER_SIZE + irepSize + END_SECTION_SIZE;
+  int32_t codeSize = HEADER_SIZE + irepSize + END_SECTION_SIZE;
   uint8_t *vmCode = mmrbc_alloc(codeSize);
   memcpy(&vmCode[0], "RITE0006", 8);
   vmCode[10] = (codeSize >> 24) & 0xff;
@@ -147,8 +147,7 @@ MrbCode *Generator_generate(Node *root)
   vmCode[8] = (crc >> 8) & 0xff;
   vmCode[9] = crc & 0xff;
   Scope_freeCodeSnippets(scope);
-  MrbCode *mrb = mmrbc_alloc(sizeof(MrbCode));
-  mrb->codeSize = codeSize;
-  mrb->vmCode = vmCode;
-  return mrb;
+  scope->vm_code = vmCode;
+  scope->vm_code_size = codeSize;
+  return scope;
 }

--- a/src/generator.c
+++ b/src/generator.c
@@ -117,16 +117,14 @@ void codegen(Scope *scope, Node *tree)
   }
 }
 
-uint8_t *flattenCode(CodeSnippet *code_snippet, int codeSize)
+void memcpyFlattenCode(uint8_t *body, CodeSnippet *code_snippet, int size)
 {
-  uint8_t *result = mmrbc_alloc(codeSize);
-  int index = 0;
+  int pos = 0;
   while (code_snippet != NULL) {
-    memcpy(&result[index], code_snippet->value, code_snippet->size);
-    index += code_snippet->size;
+    memcpy(&body[pos], code_snippet->value, code_snippet->size);
+    pos += code_snippet->size;
     code_snippet = code_snippet->next;
   }
-  return result;
 }
 
 MrbCode *Generator_generate(Node *root)
@@ -142,7 +140,7 @@ MrbCode *Generator_generate(Node *root)
   vmCode[12] = (codeSize >> 8) & 0xff;
   vmCode[13] = codeSize & 0xff;
   memcpy(&vmCode[14], "MATZ0000", 8);
-  memcpy(&vmCode[22], flattenCode(scope->code_snippet, irepSize), irepSize);
+  memcpyFlattenCode(&vmCode[22], scope->code_snippet, irepSize);
   memcpy(&vmCode[22 + irepSize], "END\0\0\0\0", 7);
   vmCode[22 + irepSize + 7] = 0x08;
   uint16_t crc = calc_crc_16_ccitt(&vmCode[10], codeSize - 10, 0);

--- a/src/generator.c
+++ b/src/generator.c
@@ -127,9 +127,8 @@ void memcpyFlattenCode(uint8_t *body, CodeSnippet *code_snippet, int size)
   }
 }
 
-Scope *Generator_generate(Node *root)
+void Generator_generate(Scope *scope, Node *root)
 {
-  Scope *scope = Scope_new(NULL);
   codegen(scope, root);
   int irepSize = Code_size(scope->code_snippet);
   int32_t codeSize = HEADER_SIZE + irepSize + END_SECTION_SIZE;
@@ -149,5 +148,4 @@ Scope *Generator_generate(Node *root)
   Scope_freeCodeSnippets(scope);
   scope->vm_code = vmCode;
   scope->vm_code_size = codeSize;
-  return scope;
 }

--- a/src/generator.h
+++ b/src/generator.h
@@ -10,6 +10,6 @@
 
 typedef struct node Node;
 
-Scope *Generator_generate(Node *root);
+void Generator_generate(Scope *scope, Node *root);
 
 #endif

--- a/src/generator.h
+++ b/src/generator.h
@@ -8,14 +8,8 @@
 #define HEADER_SIZE 22
 #define FOOTER_SIZE 8
 
-typedef struct mrb_code
-{
-  int32_t codeSize;
-  uint8_t *vmCode;
-} MrbCode;
-
 typedef struct node Node;
 
-MrbCode *Generator_generate(Node *root);
+Scope *Generator_generate(Node *root);
 
 #endif

--- a/src/scope.c
+++ b/src/scope.c
@@ -23,9 +23,27 @@ Scope *Scope_new(Scope *prev){
   return self;
 }
 
+void freeLiteralRcsv(Literal *literal)
+{
+  if (literal == NULL) return;
+  freeLiteralRcsv(literal->next);
+  mmrbc_free(literal->value);
+  mmrbc_free(literal);
+}
+
+void freeSymbolRcsv(Symbol *symbol)
+{
+  if (symbol == NULL) return;
+  freeSymbolRcsv(symbol->next);
+  mmrbc_free(symbol->value);
+  mmrbc_free(symbol);
+}
+
 void Scope_free(Scope *self)
 {
-  /* TODO */
+  freeLiteralRcsv(self->literal);
+  freeSymbolRcsv(self->symbol);
+  mmrbc_free(self);
 }
 
 void Scope_pushNCode_self(Scope *self, const uint8_t *str, int size)

--- a/src/scope.c
+++ b/src/scope.c
@@ -7,7 +7,8 @@
 
 #define IREP_HEADER_SIZE 26
 
-Scope *Scope_new(Scope *prev){
+Scope *Scope_new(Scope *prev)
+{
   Scope *self = mmrbc_alloc(sizeof(Scope));
   self->prev = prev;
   self->code_snippet = NULL;

--- a/src/scope.c
+++ b/src/scope.c
@@ -17,6 +17,8 @@ Scope *Scope_new(Scope *prev){
   self->literal = NULL;
   self->sp = 1;
   self->max_sp = 1;
+  self->vm_code = NULL;
+  self->vm_code_size = 0;
   if (prev != NULL) self->nirep++;
   return self;
 }

--- a/src/scope.c
+++ b/src/scope.c
@@ -239,3 +239,17 @@ void Scope_finish(Scope *scope)
   header->next = scope->code_snippet;
   scope->code_snippet = header;
 }
+
+void freeCodeSnippetRcsv(CodeSnippet *snippet)
+{
+  if (snippet == NULL) return;
+  freeCodeSnippetRcsv(snippet->next);
+  mmrbc_free(snippet->value);
+  mmrbc_free(snippet);
+}
+
+void Scope_freeCodeSnippets(Scope *self)
+{
+  freeCodeSnippetRcsv(self->code_snippet);
+  self->code_snippet = NULL;
+}

--- a/src/scope.h
+++ b/src/scope.h
@@ -42,6 +42,8 @@ typedef struct scope
   Literal *literal;
   int sp;
   int max_sp;
+  int32_t vm_code_size;
+  uint8_t *vm_code;
 } Scope;
 
 Scope *Scope_new(Scope *prev); 

--- a/src/scope.h
+++ b/src/scope.h
@@ -66,4 +66,6 @@ int Code_size(CodeSnippet *code_snippet);
 
 void Scope_finish(Scope *self);
 
+void Scope_freeCodeSnippets(Scope *self);
+
 #endif

--- a/src/scope.h
+++ b/src/scope.h
@@ -30,12 +30,12 @@ typedef struct code_snippet
   int size;
   uint8_t *value;
   struct code_snippet *next;
-} Code;
+} CodeSnippet;
 
 typedef struct scope
 {
   struct scope *prev;
-  struct code_snippet *code;
+  CodeSnippet *code_snippet;
   int nlocals;
   int nirep;
   Symbol *symbol;
@@ -62,7 +62,7 @@ void Scope_push(Scope *self);
 
 void Scope_pop(Scope *self);
 
-int Code_size(Code *code);
+int Code_size(CodeSnippet *code_snippet);
 
 void Scope_finish(Scope *self);
 


### PR DESCRIPTION
- [x] scope->code_snippet(list)
  - When it can be freed? - after creating mrb->vmCode
- [x] scope->code_snippet->value
  - When it can be freed? - at freeing code_snippet
- [x] uint8_t *result (in `flattenCode()` function)
  - When it can be freed? - after memcpy in `Generator_generate()`
  - It may need to change API of `flattenCode()` to be understandable
- [x] ~~MrbCode *mrb~~
  - ~~When it can be freed? - after used it in driver(compiler, REPL, etc.)~~
  - get rid of the struct
- [x] ~~mrb->vmCode~~ scope->vm_code
  - When it can be freed? - after using it
- [x] Scope *scope
  - When it can be freed? - at finishing the whole program
- [x] scope->literal(list)
  - When it can be freed? - at freeing scope
- [x] scope->symbol(list)
  - When it can be freed? - at freeing scope
