### PR TITLE
Use mrbc_init_alloc() instead of mrbc_init()

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <getopt.h>
 
-#include "../src/mrubyc/src/mrubyc.h"
+#include "../src/mrubyc/src/alloc.h"
 
 #include "../src/mmrbc.h"
 #include "../src/common.h"
@@ -86,7 +86,7 @@ int main(int argc, char * const *argv)
     memcpy(&out[strlen(in)], ".mrb\0", 5);
   }
 
-  mrbc_init(memory_pool, MEMORY_SIZE);
+  mrbc_init_alloc(memory_pool, MEMORY_SIZE);
   Scope *scope;
 
   FILE *fp;

--- a/src/common.c
+++ b/src/common.c
@@ -3,7 +3,6 @@
 #include "common.h"
 #include "debug.h"
 
-#include "mrubyc/src/mrubyc.h"
 #include "mrubyc/src/alloc.h"
 
 #ifdef MMRBC_DEBUG

--- a/src/mmrbc.h
+++ b/src/mmrbc.h
@@ -1,7 +1,6 @@
 #ifndef MMRBC_MMRBC_H_
 #define MMRBC_MMRBC_H_
 
-#include "mrubyc/src/mrubyc.h"
 #include "banned.h"
 #include "debug.h"
 #include "version.h"

--- a/statistics/.gitignore
+++ b/statistics/.gitignore
@@ -1,0 +1,6 @@
+*
+*.*
+**/
+!memcheck.rb
+!.keep
+!.gitignore


### PR DESCRIPTION
`./cli/mrbc test/fixture/hello_world.rb`

## Before : using mrbc_init()
```
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:10720, free:54812, fragment:6
(......)
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:14596, free:50936, fragment:4
Parse has completed successfully.

[1, 
 [10, 
  [13], 
  [2, 
   [14, "puts"], 
   [7, 
    [6, 
     [5], 
     [11, 
      [3, 
       [4], 
       [15, "Hello World!"], 
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:14664, free:50868, fragment:4
(......)
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:16752, free:48780, fragment:4          # Peak
(......)
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:10500, free:55032, fragment:6
[INFO]  file : common.c, line : 25, func : memcheck,
  ---MEMCHECK---
alloc_count: 141, free_count: 141
```

## After : using mrbc_init_alloc()
```
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:224, free:65308, fragment:2
(......)
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:4084, free:61448, fragment:2
Parse has completed successfully.

[1, 
 [10, 
  [13], 
  [2, 
   [14, "puts"], 
   [7, 
    [6, 
     [5], 
     [11, 
      [3, 
       [4], 
       [15, "Hello World!"], 
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:4152, free:61380, fragment:2
(......)
  Memory total:65532, used:6240, free:59292, fragment:2          # Peak
[INFO]  file : common.c, line : 20, func : print_memory,
(......)
[INFO]  file : common.c, line : 20, func : print_memory,
  Memory total:65532, used:4, free:65528, fragment:1
[INFO]  file : common.c, line : 25, func : memcheck,
  ---MEMCHECK---
alloc_count: 141, free_count: 141
```